### PR TITLE
music-player #14: Initial song playback implemented

### DIFF
--- a/music-player/src/index.html
+++ b/music-player/src/index.html
@@ -18,6 +18,7 @@
 <div class="player-wrapper">
     <h1 class="song-title">Song name</h1>
     <p class="author-name">Author name</p>
+    <audio class="song-playback" src=""></audio>
     <div class="song-progress-wrapper">
         <input id="song-progress" type="range">
         <label for="song-progress"></label>

--- a/music-player/src/script.js
+++ b/music-player/src/script.js
@@ -1,5 +1,6 @@
 const songTitle = document.querySelector(".song-title");
 const songAuthor = document.querySelector(".author-name");
+const songPlaybackElem = document.querySelector(".song-playback");
 const prevSongButton = document.querySelector(".prev-song");
 const pausePlayButton = document.querySelector(".pause-play-btn");
 const nextSongButton = document.querySelector(".next-song");
@@ -7,7 +8,7 @@ let playIconElem = createIcon("fa-solid", "fa-play");
 let pauseIconElem = createIcon("fa-solid", "fa-pause");
 
 class Track {
-    constructor(title, authorName, trackPath, albumCoverPath) {
+    constructor(title, authorName, albumCoverPath, trackPath) {
         this.title = title;
         this.authorName = authorName;
         this.trackPath = trackPath;
@@ -20,7 +21,7 @@ function initSwiper() {
         direction: 'horizontal',
         slidesPerView: "auto",
         centeredSlides: true,
-        initialSlide: currSongIdx,
+        initialSlide: initialSongIdx,
         spaceBetween: 50,
 
         effect: "coverflow",
@@ -35,25 +36,33 @@ function initSwiper() {
     });
 }
 
-function defineButtonEventHandlers() {
+function defineEventHandlers() {
     prevSongButton.addEventListener("click", () => updatePlayingSong(--currSongIdx));
     nextSongButton.addEventListener("click", () => updatePlayingSong(++currSongIdx));
-    pausePlayButton.addEventListener("click", () => {
-        updatePausePlayBtn()
-    })
+    pausePlayButton.addEventListener("click", () => setOrFlipPlayBtnState())
+    songPlaybackElem.addEventListener("canplay", () => songPlayingState ? songPlaybackElem.play() : songPlaybackElem.pause())
 }
 
 function updatePlayingSong(targetSongIdx) {
     let currTrack = tracks[targetSongIdx];
     songTitle.textContent = currTrack.title;
     songAuthor.textContent = currTrack.authorName;
+    songPlaybackElem.src = "../" + currTrack.trackPath;
+    if (!onLoadPlaybackFired && currSongIdx !== initialSongIdx) {
+        onLoadPlaybackFired = true;
+        setOrFlipPlayBtnState(true);
+    }
 }
 
-function updatePausePlayBtn() {
-    songPlayingState
-        ? pausePlayButton.replaceChild(playIconElem, pauseIconElem)
-        : pausePlayButton.replaceChild(pauseIconElem, playIconElem);
-    songPlayingState = !songPlayingState;
+function setOrFlipPlayBtnState(doPlaySong) {
+    songPlayingState = doPlaySong ?? !songPlayingState;
+    if (songPlayingState) {
+        pausePlayButton.replaceChild(pauseIconElem, playIconElem);
+        songPlaybackElem.play();
+    } else {
+        pausePlayButton.replaceChild(playIconElem, pauseIconElem);
+        songPlaybackElem.pause();
+    }
 }
 
 function createIcon(...classList) {
@@ -84,10 +93,12 @@ const tracks = [
         "assets/song-list_Dua-Lipa-Physical.mp3"
     )
 ]
-let currSongIdx = 1
+const initialSongIdx = Math.floor(tracks.length / 2);
+let currSongIdx = initialSongIdx;
 let songPlayingState = false;
+let onLoadPlaybackFired = false;
 
 initSwiper();
-updatePlayingSong(currSongIdx);
+defineEventHandlers();
 pausePlayButton.appendChild(playIconElem);
-defineButtonEventHandlers();
+updatePlayingSong(currSongIdx, false);


### PR DESCRIPTION
- Created `initialSongIdx` equal to the middle of all the available tracks (middle for odd number of tracks, middle + 1 - for even)
- Initial functions invocation order changed for proper initialization of event handlers
- Finally, add `onLoadPlaybackFired` responsible for initial playback of a song according to the required functionality in the opened issue
- The logic of initial playback is similar to the `autoplay` attribute, except that it works starting after user switches song for the first time (due to user agents `autoplay` policy)